### PR TITLE
More portable /model command

### DIFF
--- a/sidechat/sidechat
+++ b/sidechat/sidechat
@@ -380,7 +380,7 @@ while [ 0 ]; do
         elif [[ $input =~ (clip|capture|last|dui|mindwipe|choose|flash) ]]; then
             ${input:1}
         elif [[ $input == "/model" ]]; then
-            chosen=$(llm models list | fzf-tmux | cut -d ':' -f 2- | sed 's/^\s//g' )
+            chosen=$(llm models list | fzf-tmux | cut -d ':' -f 2- | cut -d ' ' -f 2 )
             if [[ -n "$chosen" ]]; then
               echo "Setting to $chosen"
               setmodel "$chosen"


### PR DESCRIPTION

## Problem(s)

After updating sidechat (after these changes https://github.com/day50-dev/sidechat/issues/3) and trying to use the `/model` command to switch model I noticed it would then error with
```
📷 —  > /model

Setting to  gw-sonnet-3.7
Memory has been wiped.

📷 —  > who are you

Error: 'Unknown model:  gw-sonnet-3.7'

📷 —  >
```
I realised the model id was being set with an extra whitespace at the beginning and `llm` was erroring because of that

Note: I was running this on Mac OS which is known to ship with old BSD versions of some binaries that often cause these kind of issues. 

This extra space is coming from the usage of sed on this line https://github.com/day50-dev/sidechat/blob/9e646da6dae2adbbb42dd45d5c763743d1a42b00/sidechat/sidechat#L383 , as I understand it BSD sed does not interpret correctly the `\s` character and the `$chosen` variable ends up including the leading whitespace.

I wondered how come I didn't face this issue before the update and I think it is likely because on this line https://github.com/day50-dev/sidechat/blob/833defce769a30ed7d5d75a131d009a2e3f8a640/sidechat/sidechat#L378 bash would get rid of the extra whitespace while setting the default model, probably because `$chosen` was not wrapped in quotes. With the recent changes (in particularly https://github.com/day50-dev/sidechat/commit/3df21a1cd2a8d65a10bd6c90ce1b39f6dab6e14d) the `"$chosen"` is now wrapped in quotes and then stored in a file and when it is then passed to `llm` it still contains the whitespace causing the error. 

I could just opt to install a GNU version of sed but I also found some another potential issue that would still likely still require some changes (see below)  

---

When I was looking at this I also realised that the existing `/model` command could be problematic when selecting any model with aliases regardless of whether the underlying `sed` as BSD or GNU. This is because line 378 above only tries to remove a whitespace preceding a model id but doesn't account for the output of `llm models list` to optionally suffix the models with strings like ` (aliases: alias1, alias2)`
eg Using  a version of sidechat from before the recent changes (eg https://github.com/day50-dev/sidechat/commit/3df21a1cd2a8d65a10bd6c90ce1b39f6dab6e14d ) and running the `/model` to select a model which has aliases would give me this error
```
📷 —  > /model

Setting to  gpt-4o (aliases: 4o)
Usage: llm models default [OPTIONS] [MODEL]
Try 'llm models default --help' for help.

Error: Got unexpected extra arguments ((aliases: 4o))
Memory has been wiped.
```

## Solution

Stop using sed with the /model command to avoid having to deal with behaviours of different sed versions and to correctly handle models with aliases

In my usage of `llm` I had to solve a similar problem and I came up with a similar command that would let me select and export a model with a command like this that would work both on my Linux and Mac OS environments. I went through various iterations trying to use sed in ways that would ensure a compatible behavious, instead I ended up using this which seems to work
```
export LLM_MODEL=$(llm models | fzf | cut -d ':' -f 2- | cut -d ' ' -f 2)
```

So this PR suggests to use the same approach: double invocation of `cut` and avoiding `sed` entirely, which would take care both the mac-specific behaviour and additionally exclude the aliases part of the string.

Side Note: It would be nice if `llm models list` would one day support more structured/stable output like json 🤷 

## Testing

I tried this locally both on mac and linux and it works correctly

some manual tests
```
$ llm models list -q 'gpt-4o' | cut -d ':' -f 2- | sed 's/^\s//g'  # previous command
 gpt-4o (aliases: 4o)
 chatgpt-4o-latest (aliases: chatgpt-4o)
 gpt-4o-mini (aliases: 4o-mini)
 gpt-4o-audio-preview
 gpt-4o-audio-preview-2024-12-17
 gpt-4o-audio-preview-2024-10-01
 gpt-4o-mini-audio-preview
 gpt-4o-mini-audio-preview-2024-12-17
 gw-gpt-4o
 gw-chatgpt-4o-latest
 gw-gpt-4o-mini
 gw-gpt-4o-audio-preview
 gw-gpt-4o-audio-preview-2024-12-17
 gw-gpt-4o-audio-preview-2024-10-01
 gw-gpt-4o-mini-audio-preview
 gw-gpt-4o-mini-audio-preview-2024-12-17
$ llm models list -q 'gpt-4o' | cut -d ':' -f 2- | cut -d ' ' -f 2 # new command
gpt-4o
chatgpt-4o-latest
gpt-4o-mini
gpt-4o-audio-preview
gpt-4o-audio-preview-2024-12-17
gpt-4o-audio-preview-2024-10-01
gpt-4o-mini-audio-preview
gpt-4o-mini-audio-preview-2024-12-17
gw-gpt-4o
gw-chatgpt-4o-latest
gw-gpt-4o-mini
gw-gpt-4o-audio-preview
gw-gpt-4o-audio-preview-2024-12-17
gw-gpt-4o-audio-preview-2024-10-01
gw-gpt-4o-mini-audio-preview
gw-gpt-4o-mini-audio-preview-2024-12-17
```

---

Let me know if this is reasonable or feel free to reject if a different solution is preferred.