### PR TITLE
Add workflow to test installer on push to main

### DIFF
--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -1,0 +1,13 @@
+name: Test Installer
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test-installer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run installer
+        run: curl -fsSL day50.dev/sidechat | sh


### PR DESCRIPTION
Built this to auto-run the installer for basic smoke test. Proved installer is broken on my forked version of sidechat here. https://github.com/sneilan/sidechat/actions/runs/21891692714/job/63198738579 

Second step shows
```
  ✅ fzf
/tmp/tmp.0PwwkKzIU5/install.sh: line 134: /home/runner/.local/bin/sd: No such file or directory
cat: write error: Broken pipe
```